### PR TITLE
Fix inifinite re-render following upgrade of react-hook-form

### DIFF
--- a/src/features/assistants/components/manage-ai-assistant-dialog.tsx
+++ b/src/features/assistants/components/manage-ai-assistant-dialog.tsx
@@ -93,14 +93,20 @@ export function ManageAiAssistantDialog(props: ManageAiAssistantDialogProps) {
 
   useEffect(() => {
     form.setValue("name", initialData?.name ?? "")
-  }, [form, initialData])
+    // HACK: On version 7.54.0 `form` is causing an infinite re-render loop
+    // so had to remove it from the dependency array which is not a big deal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialData])
 
   useEffect(() => {
     if (!open) {
       form.clearErrors()
       form.reset()
     }
-  }, [form, open])
+    // HACK: On version 7.54.0 `form` is causing an infinite re-render loop
+    // so had to remove it from the dependency array which is not a big deal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/features/assistants/components/manage-ai-prompt-config-dialog.tsx
+++ b/src/features/assistants/components/manage-ai-prompt-config-dialog.tsx
@@ -111,7 +111,10 @@ export function ManageAiPromptConfigDialog(
         ? JSON.stringify(aiPromptInput.config.promptConfig, null, 2)
         : undefined
     )
-  }, [form, aiPromptInput])
+    // HACK: On version 7.54.0 `form` is causing an infinite re-render loop
+    // so had to remove it from the dependency array which is not a big deal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [aiPromptInput])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/features/assistants/components/manage-ai-prompt-dialog.tsx
+++ b/src/features/assistants/components/manage-ai-prompt-dialog.tsx
@@ -95,7 +95,10 @@ export function ManageAiPromptDialog(props: ManageAiPromptDialogProps) {
   useEffect(() => {
     form.setValue("name", initialData?.name ?? "")
     form.setValue("prompt", initialData?.prompt ?? "")
-  }, [form, initialData])
+    // HACK: On version 7.54.0 `form` is causing an infinite re-render loop
+    // so had to remove it from the dependency array which is not a big deal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialData])
 
   useEffect(() => {
     if (!open) {
@@ -103,7 +106,10 @@ export function ManageAiPromptDialog(props: ManageAiPromptDialogProps) {
       form.resetField("name")
       form.resetField("prompt")
     }
-  }, [form, open])
+    // HACK: On version 7.54.0 `form` is causing an infinite re-render loop
+    // so had to remove it from the dependency array which is not a big deal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>


### PR DESCRIPTION
Got similar issues as https://github.com/react-hook-form/react-hook-form/issues/12463 following upgrade from 7.53.2 to 7.54.0

### What's changed?

- Removed the `form` (output of useForm) from the dependency array of the useEffect

### How to test these changes?

-

### Anything to be aware of?

-
