### PR TITLE
Remove sync trigger when connecting

### DIFF
--- a/src/features/data-connections/components/data-connections-provider.tsx
+++ b/src/features/data-connections/components/data-connections-provider.tsx
@@ -3,9 +3,7 @@
 import { useQueryClient } from "@tanstack/react-query"
 import { useEffect } from "react"
 
-import { DATA_CONNECTIONS_SYNC_INTERVAL } from "@/features/data-connections/constants"
 import { prefetchDataProviders } from "@/features/data-connections/hooks/use-data-providers"
-import { useSyncAllDataConnections } from "@/features/data-connections/hooks/use-sync-all-data-connections"
 import { Logger } from "@/features/telemetry/logger"
 
 const logger = Logger.create("data-connections")
@@ -29,20 +27,6 @@ export function DataConnectionsProvider(props: DataConnectionsProviderProps) {
       )
     })
   }, [queryClient])
-
-  // Sync all connections
-  const { syncAllConnections } = useSyncAllDataConnections()
-  useEffect(() => {
-    // Sync at startup
-    syncAllConnections()
-
-    // Sync at regular intervals
-    const interval = setInterval(() => {
-      syncAllConnections()
-    }, DATA_CONNECTIONS_SYNC_INTERVAL)
-
-    return () => clearInterval(interval)
-  }, [syncAllConnections])
 
   return <>{children}</>
 }

--- a/src/features/data-connections/constants.ts
+++ b/src/features/data-connections/constants.ts
@@ -4,8 +4,6 @@ export const DEFAULT_DATA_PROVIDER_DESCRIPTION = `Connect your account to extrac
 
 export const DATA_CONNECTIONS_CHANNEL = "data-connections"
 
-export const DATA_CONNECTIONS_SYNC_INTERVAL = 1000 * 60 * 30 // 30 minutes
-
 export const DATA_CONNECTIONS_LOGS_DB_DEF: DatabaseDefinition = {
   id: "data-connections-logs",
   type: "technical",


### PR DESCRIPTION
This pull request includes several changes to the data connections feature, focusing on removing the synchronization logic and related constants. The most important changes include the removal of the synchronization interval constant and the associated synchronization logic within the `DataConnectionsProvider` component.

### Removal of synchronization logic:

* [`src/features/data-connections/components/data-connections-provider.tsx`](diffhunk://#diff-e24f7ecf5b9025541969251d30c62cdea0acd13a9b243fa5e358adbafefb9460L6-L8): Removed the import and usage of `DATA_CONNECTIONS_SYNC_INTERVAL` and `useSyncAllDataConnections`, including the effect that handled synchronization at startup and at regular intervals. [[1]](diffhunk://#diff-e24f7ecf5b9025541969251d30c62cdea0acd13a9b243fa5e358adbafefb9460L6-L8) [[2]](diffhunk://#diff-e24f7ecf5b9025541969251d30c62cdea0acd13a9b243fa5e358adbafefb9460L33-L46)

### Removal of related constants:

* [`src/features/data-connections/constants.ts`](diffhunk://#diff-f33850d74dfe89bb62ad37975f82ae337f9401e3647763fc1f826c3c68972ab3L7-L8): Removed the `DATA_CONNECTIONS_SYNC_INTERVAL` constant.